### PR TITLE
[FIX] compatible with Gdk 4.0 systems

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
 import logging
+import gi
+gi.require_version('Gdk', '3.0')
 from ulauncher.api.client.Extension import Extension
 from ulauncher.api.client.EventListener import EventListener
 from ulauncher.api.shared.event import KeywordQueryEvent, ItemEnterEvent


### PR DESCRIPTION
Thanks for this plugin !

This PR fixes an issue on systems with Gdk 4.0 required (such as Gnome 40) that would cause the extension to exit instantly.
(See https://github.com/Ulauncher/Ulauncher/issues/703 for more context)

This PR explicitely manually import Gdk and specify the version compatible, which allow this plugin to not crash until Ulauncher/Ulauncher#717 is merged